### PR TITLE
updates for .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 framework
 
 .DS_Store
+
+.env
+web.config

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@koopjs/koop-core": "^10.3.1",
         "config": "^3.2.4",
+        "dotenv": "^16.4.5",
         "fs-extra": "^9.0.1",
         "klaw-sync": "^6.0.0",
         "node-fetch": "^2.6.0"
@@ -1153,6 +1154,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/easy-table": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@koopjs/koop-core": "^10.3.1",
     "config": "^3.2.4",
+    "dotenv": "^16.4.5",
     "fs-extra": "^9.0.1",
     "klaw-sync": "^6.0.0",
     "node-fetch": "^2.6.0"

--- a/providers/dhis2/src/model.js
+++ b/providers/dhis2/src/model.js
@@ -12,9 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const config = require("../../../config/default.json");
+// const config = require("../../../config/default.json");
 const parseGeoJSON = require("./parseGeoJson");
-const apiKey = config.dhis2.apiKey;
+require("dotenv").config();
+
+const apiKey = process.env.DHIS2_TOKEN;
+
 let geojson = null;
 const fetch = require("node-fetch");
 
@@ -27,8 +30,8 @@ function Model(koop) {}
 Model.prototype.getData = function (req, callback) {
   try {
     const { host, id } = req.params;
-    let url = `${config/dhis2.serverURL}/geoFeatures.geojson?ou=ou%3ALEVEL-3%3BImspTQPwCqd&displayProperty=NAME`;
-    let dimUrl = `${config/dhis2.serverURL}/analytics.json?dimension=dx:Tt5TAvdfdVK&dimension=ou:ImspTQPwCqd;LEVEL-3&filter=pe:LAST_12_MONTHS&displayProperty=NAME&skipData=false&skipMeta=true`;
+    let url = `${process.env.DHIS2_SERVER}/geoFeatures.geojson?ou=ou%3ALEVEL-3%3BImspTQPwCqd&displayProperty=NAME`;
+    let dimUrl = `${process.env.DHIS2_SERVER}/analytics.json?dimension=dx:Tt5TAvdfdVK&dimension=ou:ImspTQPwCqd;LEVEL-3&filter=pe:LAST_12_MONTHS&displayProperty=NAME&skipData=false&skipMeta=true`;
 
     fetch(url, {
       headers: {

--- a/providers/facilities/src/model.js
+++ b/providers/facilities/src/model.js
@@ -12,9 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const config = require("../../../config/default.json");
+// const config = require("../../../config/default.json");
 const parseGeoJSON = require("./parseGeoJson");
-const apiKey = config.dhis2.apiKey;
+require("dotenv").config();
+const apiKey = process.env.DHIS2_TOKEN;
 let geojson = null;
 const fetch = require("node-fetch");
 function Model(koop) {}
@@ -23,7 +24,7 @@ function Model(koop) {}
 // Each model should have a getData() function to fetch the geo data
 // and format it into a geojson
 Model.prototype.getData = function (req, callback) {
-  let url = `${config.dhis2.serverURL}/39/geoFeatures.json?includeGroupSets=false&ou=ou%3AImspTQPwCqd%3BLEVEL-m9lBJogzE95&displayProperty=NAME`;
+  let url = `${process.env.DHIS2_SERVER}/39/geoFeatures.json?includeGroupSets=false&ou=ou%3AImspTQPwCqd%3BLEVEL-m9lBJogzE95&displayProperty=NAME`;
   fetch(url, {
     headers: {
       Authorization: apiKey,

--- a/providers/malariacases/src/model.js
+++ b/providers/malariacases/src/model.js
@@ -12,10 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const config = require("../../../config/default.json");
+// const config = require("../../../config/default.json");
 const getFields = require("../../../utils/getFields");
 const parseGeoJSON = require("./parseGeoJson");
-const apiKey = config.dhis2.apiKey;
+require("dotenv").config();
+
+const apiKey = process.env.DHIS2_TOKEN;
+
+console.log("hi", apiKey);
 const fetch = require("node-fetch");
 
 const headerOverrides = {
@@ -36,7 +40,7 @@ Model.prototype.getData = function (req, callback) {
   try {
     console.log("Params", req.query);
     const { host, id } = req.params;
-    let url = `${config.dhis2.serverURL}/analytics/events/query/VBqh0ynB2wv.json?dimension=ou:ImspTQPwCqd&dimension=F3ogKBuviRA&dimension=${id}&dimension=${host}&filter=pe:LAST_MONTH&stage=pTo4uMt3xur&coordinatesOnly=true&coordinateField=F3ogKBuviRA&eventStatus=ACTIVE&pageSize=110000`;
+    let url = `${process.env.DHIS2_SERVER}/analytics/events/query/VBqh0ynB2wv.json?dimension=ou:ImspTQPwCqd&dimension=F3ogKBuviRA&dimension=${id}&dimension=${host}&filter=pe:LAST_MONTH&stage=pTo4uMt3xur&coordinatesOnly=true&coordinateField=F3ogKBuviRA&eventStatus=ACTIVE&pageSize=110000`;
     console.log("URL", url);
     fetch(url, {
       headers: {

--- a/src/index.js
+++ b/src/index.js
@@ -12,25 +12,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const config = require('config')
-const Koop = require('@koopjs/koop-core')
-const routes = require('./routes')
-const plugins = require('./plugins')
+const config = require("config");
+const Koop = require("@koopjs/koop-core");
+const routes = require("./routes");
+const plugins = require("./plugins");
+
+// require("dotenv").config();
 
 // initiate a koop app
-const koop = new Koop()
+const koop = new Koop();
 
 // register koop plugins
 plugins.forEach((plugin) => {
-  koop.register(plugin.instance, plugin.options)
-})
+  koop.register(plugin.instance, plugin.options);
+});
 
 // add additional routes
 routes.forEach((route) => {
   route.methods.forEach((method) => {
-    koop.server[method](route.path, route.handler)
-  })
-})
+    koop.server[method](route.path, route.handler);
+  });
+});
 
 // start the server
-koop.server.listen(config.port, () => koop.log.info(`Server listening at ${config.port}`))
+koop.server.listen(process.env.PORT || config.port, () =>
+  koop.log.info(`Server listening at ${config.port}`)
+);


### PR DESCRIPTION
we added the ability to pull in DHIS2 token and server url via `dotenv` .env files. this is because the tokens for DHIS2 change frequently and all we have to do is update the Azure app service with the new token and then restart the app service.